### PR TITLE
Stop Observable methods from being enumerable

### DIFF
--- a/src/module/object-observer.js
+++ b/src/module/object-observer.js
@@ -23,7 +23,10 @@ const
 		revoke: {
 			value: function() {
 				this[sysObsKey].revoke();
-			}
+			},
+			enumerable: false,
+			configurable: true,
+			writable: false
 		},
 		observe: {
 			value: function(observer) {
@@ -37,7 +40,10 @@ const
 				} else {
 					console.info('observer may be bound to an observable only once');
 				}
-			}
+			},
+			enumerable: false,
+			configurable: true,
+			writable: false
 		},
 		unobserve: {
 			value: function() {
@@ -54,7 +60,10 @@ const
 				} else {
 					observers.splice(0);
 				}
-			}
+			},
+			enumerable: false,
+			configurable: true,
+			writable: false
 		}
 	},
 	prepareArray = function(origin, destination, observer) {


### PR DESCRIPTION
When I was using this project, I needed to assign my object entries to another object. However, since the Observable instance has its own methods (revoke, observe, unobserve), you can't list easily the object properties without doing some filtering (which can be broken if the API makes some breaking changes or add new methods).

That's why I thought that making the methods as non-enumerable could be a good solution to this problem.

Another thing is that the methods added through the Observable.from should also not be edited. For example if someone try to overwrite the revoke property of its object, it could break the script behavior. One way to stop this is to make the properties as non-writable.

Finally for the same reason I made them as configurable. Therefore, if someone really wants to overwrite these functions, he can overwrite the prototype properties (writable to true) and write on top of the properties.