### PR TITLE
#issue 21: Observing specific path functionality.

### DIFF
--- a/src/object-observer.js
+++ b/src/object-observer.js
@@ -100,8 +100,8 @@ const
 				const target = observers[l]
 				const { path } = target.options
 				if (path) {
-					let relevantChanges = changes.every((change) => change.path.join('.').startsWith(path))
-					if (relevantChanges) {
+					let relevantChanges = changes.filter((change) => change.path.join('.').startsWith(path))
+					if (relevantChanges.length) {
 						target.observer(changes);
 					}
 				} else {

--- a/src/object-observer.js
+++ b/src/object-observer.js
@@ -99,10 +99,12 @@ const
 			try {
 				const target = observers[l]
 				const { path } = target.options
-
-				if (path && changes.every((change) => change.path.join('.').startsWith(path))) {
-					target.observer(changes);
-				} else if (!path) {
+				if (path) {
+					let relevantChanges = changes.every((change) => change.path.join('.').startsWith(path))
+					if (relevantChanges) {
+						target.observer(changes);
+					}
+				} else {
 					target.observer(changes);
 				}
 			} catch (e) {

--- a/src/object-observer.js
+++ b/src/object-observer.js
@@ -99,13 +99,12 @@ const
 			try {
 				const target = observers[l]
 				const { path } = target.options
-				
-				if (path && path.split(".").every((value, index) => changes[0].path[index] === value)) {
+
+				if (path && changes.every((change) => change.path.join('.').startsWith(path))) {
 					target.observer(changes);
-				} else if(!path) {
+				} else if (!path) {
 					target.observer(changes);
 				}
-				
 			} catch (e) {
 				console.error('failed to deliver changes to listener' + observers[l], e);
 			}

--- a/src/object-observer.js
+++ b/src/object-observer.js
@@ -26,15 +26,19 @@ const
 			}
 		},
 		observe: {
-			value: function (observer) {
+			value: function (observer, options = {}) {
 				let systemObserver = this[sysObsKey],
 					observers = systemObserver.observers;
+
 				if (typeof observer !== 'function') {
 					throw new Error('observer parameter MUST be a function');
 				}
 
 				if (observers.indexOf(observer) < 0) {
-					observers.push(observer);
+					observers.push({
+						observer,
+						options
+					});
 				} else {
 					console.info('observer may be bound to an observable only once');
 				}
@@ -93,7 +97,15 @@ const
 		let l = observers.length;
 		while (l--) {
 			try {
-				observers[l](changes);
+				const target = observers[l]
+				const { path } = target.options
+				
+				if (path && path.split(".").every((value, index) => changes[0].path[index] === value)) {
+					target.observer(changes);
+				} else if(!path) {
+					target.observer(changes);
+				}
+				
 			} catch (e) {
 				console.error('failed to deliver changes to listener' + observers[l], e);
 			}


### PR DESCRIPTION
I added functionality to configure the observer, so some options can also be provided.

For example 

```JS
  const data = {
            "name":"test",
            "location": {
                "country":"Random country",
                "city":"Random city",
                "more": {
                    "name":"test name"
                }
            }
        }

        const observer = Observable.from(data)
        observer.observe((changes) => { console.log(changes) }, {path: "location.more"})

        
        observer.name = "new name"
        
        observer.location.city = "new city"
        observer.location.more.name = "more names"

```

Here the `path` option is provided and only the defined path + its children are observed.

But i did not get the `tests` fully working and i did not find the failing ones because the test framework was unknown to me.

Perhaps this pull is useful.