### PR TITLE
add new change type `access` to trap `get()` with `enableGet` (default off)

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
     "name": "Guller Yuri",
     "email": "gullerya@gmail.com"
   },
+  "contributors": [
+    "Ali Chamas <dragonworxau@yahoo.com.au> (https://github.com/dragonworx/)"
+  ],
   "funding": "https://paypal.me/gullerya?locale.x=en_US",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Adds a new change type **ACCESS** (`access`) to trap `get()` accessors.
Enabled via `enableGet` option of `.observe()` with default `false`.