### PR TITLE
Fix pathsOf when observing array changes

### DIFF
--- a/src/object-observer.js
+++ b/src/object-observer.js
@@ -111,9 +111,11 @@ const
 				);
 			} else if (options.pathsOf) {
 				const oPathsOf = options.pathsOf;
+				const oPathsOfStr = oPathsOf.join(".");
 				result = changes.filter(change =>
-					change.path.length === oPathsOf.length + 1 ||
-					(change.path.length === oPathsOf.length && (change.type === REVERSE || change.type === SHUFFLE))
+					(change.path.length === oPathsOf.length + 1 ||
+					(change.path.length === oPathsOf.length && (change.type === REVERSE || change.type === SHUFFLE))) &&
+					change.path.join(".").startsWith(oPathsOfStr)
 				);
 			} else if (options.pathsFrom) {
 				const oPathsFrom = options.pathsFrom;

--- a/tests/observe-specific-paths.js
+++ b/tests/observe-specific-paths.js
@@ -118,6 +118,19 @@ suite.runTest({ name: 'observe paths of - inner case' }, test => {
 	test.assertEqual(2, counter);
 });
 
+suite.runTest({ name: 'observe paths of - array - property of same depth updated' }, test => {
+	const oo = Observable.from({ array: [1, 2, 3], prop: { inner: 'value' } });
+	let counter = 0;
+	oo.observe(changes => { counter += changes.length; }, { pathsOf: 'array' });
+	oo.nonRelevant = 'non-relevant';
+	oo.prop.inner = 'non-relevant';
+	oo.prop = { newObj: { test: 'non-relevant' } };
+	oo.array.pop();
+	oo.array.push({newObj: { test: 'relevant' }});
+	oo.array[2].newObj.test = 'non-relevant';
+	test.assertEqual(2, counter);
+});
+
 suite.runTest({ name: 'observe paths of - root case' }, test => {
 	const oo = Observable.from({ inner: { prop: 'more', nested: { text: 'text' } } });
 	let counter = 0;


### PR DESCRIPTION
The current implementation of pathsOf just checks the for the depth of the change, so any change of the correct depth matches even if it originates from a path that doesn't start with the specified pathsOf value. This PR updates the filter criteria to also check that the path of the change starts with the pathsOf value.